### PR TITLE
Fixed typographical error, changed accidentaly to accidentally in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ My XMPP knowledge is pretty basic (if there is a level below basic, I'm there!).
 I can't guarantee this will work for all XMPP clients out there. 
 
 In fact, I guarantee nothing. *xmpp-to-tlen* does its best to provide a smooth
-experience, but if there are messages lost, contacts accidentaly removed or
+experience, but if there are messages lost, contacts accidentally removed or
 your computer suddenly explodes -- don't blame me.
 
 Having that out of the way, these clients are known to work:


### PR DESCRIPTION
@kgodlewski, I've corrected a typographical error in the documentation of the [xmpp-to-tlen](https://github.com/kgodlewski/xmpp-to-tlen) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.